### PR TITLE
support for mac newline detection

### DIFF
--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 open class CSV {
-    static fileprivate let comma: Character = ","
+    static public let comma: Character = ","
     
     open let header: [String]
 

--- a/SwiftCSV/ParsingState.swift
+++ b/SwiftCSV/ParsingState.swift
@@ -8,7 +8,7 @@
 
 fileprivate extension Character {
     var isNewline: Bool {
-        return self == "\n" || self == "\r\n"
+        return self == "\n" || self == "\r\n" || self == "\r"
     }
 }
 


### PR DESCRIPTION
As described by @bcitdaltond:

https://github.com/naoty/SwiftCSV/issues/56

This PR applies the given solution to support the newlines produced on Mac, which is just a carriage return.

