### PR TITLE
Fix for Swift 4

### DIFF
--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 open class CSV {
-    static fileprivate let comma: Character = ","
+    static public let comma: Character = ","
     
     open let header: [String]
 


### PR DESCRIPTION
Swift 4 requires that default parameters have at least the same access level as the function itself. And it looks OK to expose the comma as a public constant.