### PR TITLE
Support Swift Package Manager.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+.build/
 
 # CocoaPods
 #

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftCSV",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "SwiftCSV",
+            targets: ["SwiftCSV"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "SwiftCSV",
+            path: "SwiftCSV"),
+        .testTarget(
+            name: "SwiftCSVTests",
+            dependencies: ["SwiftCSV"],
+            path: "SwiftCSVTests"),
+    ]
+)

--- a/SwiftCSV.xcodeproj/project.pbxproj
+++ b/SwiftCSV.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		E46085921CCB1E8F00385286 /* large.csv in Resources */ = {isa = PBXBuildFile; fileRef = E46085911CCB1E8F00385286 /* large.csv */; };
 		E46085941CCB1F5C00385286 /* PerformanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46085931CCB1F5C00385286 /* PerformanceTest.swift */; };
 		F5C19F502283243C00920B06 /* ResourceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C19F4F2283243C00920B06 /* ResourceHelper.swift */; };
+		F5C19F512283C0C100920B06 /* ResourceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C19F4F2283243C00920B06 /* ResourceHelper.swift */; };
+		F5C19F522283C0C300920B06 /* ResourceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C19F4F2283243C00920B06 /* ResourceHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -589,6 +591,7 @@
 			files = (
 				5FB74BE01CCB9312009DDBF1 /* CSVTests.swift in Sources */,
 				5FB74BE11CCB9312009DDBF1 /* QuotedTests.swift in Sources */,
+				F5C19F512283C0C100920B06 /* ResourceHelper.swift in Sources */,
 				508975E21DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */,
 				5FB74BE21CCB9312009DDBF1 /* TSVTests.swift in Sources */,
 				5FB74BE31CCB9312009DDBF1 /* URLTests.swift in Sources */,
@@ -616,6 +619,7 @@
 			files = (
 				5FB74BE51CCB931F009DDBF1 /* CSVTests.swift in Sources */,
 				5FB74BE61CCB931F009DDBF1 /* QuotedTests.swift in Sources */,
+				F5C19F522283C0C300920B06 /* ResourceHelper.swift in Sources */,
 				508975E31DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */,
 				5FB74BE71CCB931F009DDBF1 /* TSVTests.swift in Sources */,
 				5FB74BE81CCB931F009DDBF1 /* URLTests.swift in Sources */,

--- a/SwiftCSV.xcodeproj/project.pbxproj
+++ b/SwiftCSV.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		BEE5461E1CBBB15900C0666F /* Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE5461D1CBBB15900C0666F /* Description.swift */; };
 		E46085921CCB1E8F00385286 /* large.csv in Resources */ = {isa = PBXBuildFile; fileRef = E46085911CCB1E8F00385286 /* large.csv */; };
 		E46085941CCB1F5C00385286 /* PerformanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46085931CCB1F5C00385286 /* PerformanceTest.swift */; };
+		F5C19F502283243C00920B06 /* ResourceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C19F4F2283243C00920B06 /* ResourceHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -124,6 +125,7 @@
 		BEE5461D1CBBB15900C0666F /* Description.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Description.swift; sourceTree = "<group>"; };
 		E46085911CCB1E8F00385286 /* large.csv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = large.csv; sourceTree = "<group>"; };
 		E46085931CCB1F5C00385286 /* PerformanceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTest.swift; sourceTree = "<group>"; };
+		F5C19F4F2283243C00920B06 /* ResourceHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResourceHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -243,6 +245,7 @@
 				BE06B67C1CB7267B009578CC /* empty_fields.csv */,
 				BE06B6811CB7287F009578CC /* quotes.csv */,
 				E46085911CCB1E8F00385286 /* large.csv */,
+				F5C19F4F2283243C00920B06 /* ResourceHelper.swift */,
 			);
 			name = Res;
 			sourceTree = "<group>";
@@ -558,6 +561,7 @@
 			files = (
 				E46085941CCB1F5C00385286 /* PerformanceTest.swift in Sources */,
 				3D1E59C71945FFAD001CF760 /* CSVTests.swift in Sources */,
+				F5C19F502283243C00920B06 /* ResourceHelper.swift in Sources */,
 				508975E11DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */,
 				3D3749E3194D6DF7008F262A /* TSVTests.swift in Sources */,
 				BE06B6801CB726B5009578CC /* URLTests.swift in Sources */,

--- a/SwiftCSVTests/PerformanceTest.swift
+++ b/SwiftCSVTests/PerformanceTest.swift
@@ -13,7 +13,7 @@ class PerformanceTest: XCTestCase {
     var csv: CSV!
 
     override func setUp() {
-        let csvURL = Bundle(for: CSVTests.self).url(forResource: "large", withExtension: "csv")!
+        let csvURL = ResourceHelper.url(forResource: "large", withExtension: "csv")!
         csv = try! CSV(url: csvURL)
     }
 

--- a/SwiftCSVTests/ResourceHelper.swift
+++ b/SwiftCSVTests/ResourceHelper.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// Find url of resource.
+// This is a workaround for SwiftPM, becasue SwiftPM is not yet support for include resources with targets.(https://bugs.swift.org/browse/SR-2866)
 struct ResourceHelper {
     static func url(forResource name: String, withExtension type: String) -> URL? {
         let bundle = Bundle(for: CSVTests.self)

--- a/SwiftCSVTests/ResourceHelper.swift
+++ b/SwiftCSVTests/ResourceHelper.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct ResourceHelper {
+    static func url(forResource name: String, withExtension type: String) -> URL? {
+        let bundle = Bundle(for: CSVTests.self)
+        if let url = bundle.url(forResource: name, withExtension: type) {
+            return url
+        } else if let realBundle = Bundle(path: "\(bundle.bundlePath)/../../../../SwiftCSVTests") {
+            return realBundle.url(forResource: name, withExtension: type)
+        } else {
+            return nil
+        }
+    }
+}

--- a/SwiftCSVTests/URLTests.swift
+++ b/SwiftCSVTests/URLTests.swift
@@ -13,7 +13,7 @@ class URLTests: XCTestCase {
     var csv: CSV!
     
     func testEmptyFields() {
-        let csvURL = Bundle(for: CSVTests.self).url(forResource: "empty_fields", withExtension: "csv")!
+        let csvURL = ResourceHelper.url(forResource: "empty_fields", withExtension: "csv")!
         csv = try! CSV(url: csvURL)
         let expected = [
             ["id": "1", "name": "John", "age": "23"],
@@ -29,7 +29,7 @@ class URLTests: XCTestCase {
     }
     
     func testQuotes() {
-        let csvURL = Bundle(for: CSVTests.self).url(forResource: "quotes", withExtension: "csv")!
+        let csvURL = ResourceHelper.url(forResource: "quotes", withExtension: "csv")!
         csv = try! CSV(url: csvURL)
         let expected = [
             ["id": "4", "name, first": "Alex", "name, last": "Smith"],


### PR DESCRIPTION
I find this repo when I try to make a small tool to parse csv files. It's awesome! But the only regret is that it does not support SPM. So I made this PR to do something for others.

It is easy to use new version of swift tool. But there is one not good of SPM, it does not support include resources with targets, it's a [bug](https://bugs.swift.org/browse/SR-2866). So, in order to pass the test case, I added a `ResourceHelper` to get the url of resource.
