### PR TITLE
Release 0.5.6

### DIFF
--- a/SwiftCSV.podspec
+++ b/SwiftCSV.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftCSV"
-  s.version      = "0.5.5"
+  s.version      = "0.5.6"
   s.summary      = "CSV parser for Swift"
   s.homepage     = "https://github.com/swiftcsv/SwiftCSV"
   s.license      = { :type => "MIT", :file => "LICENSE" }

--- a/SwiftCSV.xcodeproj/SwiftCSV-Info.plist
+++ b/SwiftCSV.xcodeproj/SwiftCSV-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.0</string>
+	<string>0.5.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This PR bumps the version number to 0.5.6. It contains the changes for adding quotes to the `description` property from #86. I assume bumping the patch number is fine for this sort of change?

Having read the [contributing guidelines](https://github.com/swiftcsv/SwiftCSV/blob/master/CONTRIBUTING.md#publishing-new-releases) I'm not sure I have permission to add tags to master and release a new version of the cocoapod. Is there anything more I need to do in this PR?