### PR TITLE
Passing `limitTo` param from `Parser.array()` to `enumerateAsArray`

### DIFF
--- a/SwiftCSV/Parser.swift
+++ b/SwiftCSV/Parser.swift
@@ -26,7 +26,7 @@ enum Parser {
 
         var rows = [[String]]()
 
-        try enumerateAsArray(text: text, delimiter: delimiter) { row in
+        try enumerateAsArray(text: text, delimiter: delimiter, limitTo: limitTo) { row in
             rows.append(row)
         }
 


### PR DESCRIPTION
Otherwise, things like CSV.init(string: String, delimiter: Character = comma, loadColumns: Bool = true) will parse the whole string when just trying to get the headers.

For large inputs, this was noticeable wasted work.

I think this was an oversight, but it does break the test `testThrowsOnInvalidData`. I think that test is of dubious value and just kinda incidentally worked.