### PR TITLE
Introduce delimiter guessing

### DIFF
--- a/SwiftCSV.xcodeproj/project.pbxproj
+++ b/SwiftCSV.xcodeproj/project.pbxproj
@@ -30,6 +30,13 @@
 		508975E11DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975E01DBF3E51006F3DBE /* EnumeratedViewTests.swift */; };
 		508975E21DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975E01DBF3E51006F3DBE /* EnumeratedViewTests.swift */; };
 		508975E31DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975E01DBF3E51006F3DBE /* EnumeratedViewTests.swift */; };
+		508CA0FB2771F2E70084C8E8 /* CSV+DelimiterGuessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508CA0FA2771F2E70084C8E8 /* CSV+DelimiterGuessing.swift */; };
+		508CA0FD2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508CA0FC2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift */; };
+		508CA0FE2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508CA0FC2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift */; };
+		508CA0FF2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508CA0FC2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift */; };
+		508CA1002771F32C0084C8E8 /* CSV+DelimiterGuessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508CA0FA2771F2E70084C8E8 /* CSV+DelimiterGuessing.swift */; };
+		508CA1022771F32D0084C8E8 /* CSV+DelimiterGuessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508CA0FA2771F2E70084C8E8 /* CSV+DelimiterGuessing.swift */; };
+		508CA1032771F32E0084C8E8 /* CSV+DelimiterGuessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508CA0FA2771F2E70084C8E8 /* CSV+DelimiterGuessing.swift */; };
 		5FB74B9B1CCB9274009DDBF1 /* SwiftCSV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FB74B911CCB9274009DDBF1 /* SwiftCSV.framework */; };
 		5FB74BB71CCB929D009DDBF1 /* SwiftCSV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FB74BAD1CCB929D009DDBF1 /* SwiftCSV.framework */; };
 		5FB74BD11CCB92E5009DDBF1 /* CSV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAAEE9B1C74C7EC00A933DB /* CSV.swift */; };
@@ -118,6 +125,8 @@
 		508975D61DBF34CF006F3DBE /* ParsingState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParsingState.swift; sourceTree = "<group>"; };
 		508975DB1DBF3B70006F3DBE /* EnumeratedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumeratedView.swift; sourceTree = "<group>"; };
 		508975E01DBF3E51006F3DBE /* EnumeratedViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumeratedViewTests.swift; sourceTree = "<group>"; };
+		508CA0FA2771F2E70084C8E8 /* CSV+DelimiterGuessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CSV+DelimiterGuessing.swift"; sourceTree = "<group>"; };
+		508CA0FC2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CSV+DelimiterGuessingTests.swift"; sourceTree = "<group>"; };
 		50F241A4274BB8DB00520A69 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		5FB74B911CCB9274009DDBF1 /* SwiftCSV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCSV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FB74B9A1CCB9274009DDBF1 /* SwiftCSVTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftCSVTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -223,6 +232,7 @@
 			isa = PBXGroup;
 			children = (
 				3DAAEE9B1C74C7EC00A933DB /* CSV.swift */,
+				508CA0FA2771F2E70084C8E8 /* CSV+DelimiterGuessing.swift */,
 				508975D11DBB897A006F3DBE /* NamedView.swift */,
 				508975DB1DBF3B70006F3DBE /* EnumeratedView.swift */,
 				3D444BCC1C7D88290001C60C /* String+Lines.swift */,
@@ -238,6 +248,7 @@
 			children = (
 				BE06B67E1CB72680009578CC /* Res */,
 				3D1E59C61945FFAD001CF760 /* CSVTests.swift */,
+				508CA0FC2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift */,
 				508975E01DBF3E51006F3DBE /* EnumeratedViewTests.swift */,
 				BE6C86061CB5CE44009A351D /* QuotedTests.swift */,
 				3D3749E2194D6DF7008F262A /* TSVTests.swift */,
@@ -555,6 +566,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				508975D21DBB897A006F3DBE /* NamedView.swift in Sources */,
+				508CA0FB2771F2E70084C8E8 /* CSV+DelimiterGuessing.swift in Sources */,
 				BEE5461E1CBBB15900C0666F /* Description.swift in Sources */,
 				3DAAEE9C1C74C7EC00A933DB /* CSV.swift in Sources */,
 				BE9B02D81CBE57B8009FE424 /* Parser.swift in Sources */,
@@ -570,6 +582,7 @@
 			files = (
 				E46085941CCB1F5C00385286 /* PerformanceTest.swift in Sources */,
 				3D1E59C71945FFAD001CF760 /* CSVTests.swift in Sources */,
+				508CA0FD2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift in Sources */,
 				F5C19F502283243C00920B06 /* ResourceHelper.swift in Sources */,
 				508975E11DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */,
 				5015AD8A274BA20A0050F975 /* ParserTests.swift in Sources */,
@@ -584,6 +597,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				508975D31DBB897A006F3DBE /* NamedView.swift in Sources */,
+				508CA1002771F32C0084C8E8 /* CSV+DelimiterGuessing.swift in Sources */,
 				5FB74BD11CCB92E5009DDBF1 /* CSV.swift in Sources */,
 				5FB74BD21CCB92E5009DDBF1 /* String+Lines.swift in Sources */,
 				508975DD1DBF3B70006F3DBE /* EnumeratedView.swift in Sources */,
@@ -599,6 +613,7 @@
 			files = (
 				5FB74BE01CCB9312009DDBF1 /* CSVTests.swift in Sources */,
 				5FB74BE11CCB9312009DDBF1 /* QuotedTests.swift in Sources */,
+				508CA0FE2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift in Sources */,
 				F5C19F512283C0C100920B06 /* ResourceHelper.swift in Sources */,
 				508975E21DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */,
 				5015AD8B274BA20A0050F975 /* ParserTests.swift in Sources */,
@@ -613,6 +628,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				508975D41DBB897A006F3DBE /* NamedView.swift in Sources */,
+				508CA1022771F32D0084C8E8 /* CSV+DelimiterGuessing.swift in Sources */,
 				5FB74BD61CCB92EB009DDBF1 /* CSV.swift in Sources */,
 				5FB74BD71CCB92EB009DDBF1 /* String+Lines.swift in Sources */,
 				508975DE1DBF3B70006F3DBE /* EnumeratedView.swift in Sources */,
@@ -628,6 +644,7 @@
 			files = (
 				5FB74BE51CCB931F009DDBF1 /* CSVTests.swift in Sources */,
 				5FB74BE61CCB931F009DDBF1 /* QuotedTests.swift in Sources */,
+				508CA0FF2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift in Sources */,
 				F5C19F522283C0C300920B06 /* ResourceHelper.swift in Sources */,
 				508975E31DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */,
 				5015AD8C274BA20A0050F975 /* ParserTests.swift in Sources */,
@@ -642,6 +659,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				508975D51DBB897A006F3DBE /* NamedView.swift in Sources */,
+				508CA1032771F32E0084C8E8 /* CSV+DelimiterGuessing.swift in Sources */,
 				5FB74BDB1CCB92F1009DDBF1 /* CSV.swift in Sources */,
 				5FB74BDC1CCB92F1009DDBF1 /* String+Lines.swift in Sources */,
 				508975DF1DBF3B70006F3DBE /* EnumeratedView.swift in Sources */,

--- a/SwiftCSV.xcodeproj/project.pbxproj
+++ b/SwiftCSV.xcodeproj/project.pbxproj
@@ -37,6 +37,9 @@
 		508CA1002771F32C0084C8E8 /* CSV+DelimiterGuessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508CA0FA2771F2E70084C8E8 /* CSV+DelimiterGuessing.swift */; };
 		508CA1022771F32D0084C8E8 /* CSV+DelimiterGuessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508CA0FA2771F2E70084C8E8 /* CSV+DelimiterGuessing.swift */; };
 		508CA1032771F32E0084C8E8 /* CSV+DelimiterGuessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508CA0FA2771F2E70084C8E8 /* CSV+DelimiterGuessing.swift */; };
+		508CA1052772039E0084C8E8 /* CSVDelimiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508CA1042772039E0084C8E8 /* CSVDelimiterTests.swift */; };
+		508CA1062772039E0084C8E8 /* CSVDelimiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508CA1042772039E0084C8E8 /* CSVDelimiterTests.swift */; };
+		508CA1072772039E0084C8E8 /* CSVDelimiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508CA1042772039E0084C8E8 /* CSVDelimiterTests.swift */; };
 		5FB74B9B1CCB9274009DDBF1 /* SwiftCSV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FB74B911CCB9274009DDBF1 /* SwiftCSV.framework */; };
 		5FB74BB71CCB929D009DDBF1 /* SwiftCSV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FB74BAD1CCB929D009DDBF1 /* SwiftCSV.framework */; };
 		5FB74BD11CCB92E5009DDBF1 /* CSV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAAEE9B1C74C7EC00A933DB /* CSV.swift */; };
@@ -127,6 +130,7 @@
 		508975E01DBF3E51006F3DBE /* EnumeratedViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumeratedViewTests.swift; sourceTree = "<group>"; };
 		508CA0FA2771F2E70084C8E8 /* CSV+DelimiterGuessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CSV+DelimiterGuessing.swift"; sourceTree = "<group>"; };
 		508CA0FC2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CSV+DelimiterGuessingTests.swift"; sourceTree = "<group>"; };
+		508CA1042772039E0084C8E8 /* CSVDelimiterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSVDelimiterTests.swift; sourceTree = "<group>"; };
 		50F241A4274BB8DB00520A69 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		5FB74B911CCB9274009DDBF1 /* SwiftCSV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCSV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FB74B9A1CCB9274009DDBF1 /* SwiftCSVTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftCSVTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -249,6 +253,7 @@
 				BE06B67E1CB72680009578CC /* Res */,
 				3D1E59C61945FFAD001CF760 /* CSVTests.swift */,
 				508CA0FC2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift */,
+				508CA1042772039E0084C8E8 /* CSVDelimiterTests.swift */,
 				508975E01DBF3E51006F3DBE /* EnumeratedViewTests.swift */,
 				BE6C86061CB5CE44009A351D /* QuotedTests.swift */,
 				3D3749E2194D6DF7008F262A /* TSVTests.swift */,
@@ -584,6 +589,7 @@
 				3D1E59C71945FFAD001CF760 /* CSVTests.swift in Sources */,
 				508CA0FD2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift in Sources */,
 				F5C19F502283243C00920B06 /* ResourceHelper.swift in Sources */,
+				508CA1052772039E0084C8E8 /* CSVDelimiterTests.swift in Sources */,
 				508975E11DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */,
 				5015AD8A274BA20A0050F975 /* ParserTests.swift in Sources */,
 				3D3749E3194D6DF7008F262A /* TSVTests.swift in Sources */,
@@ -615,6 +621,7 @@
 				5FB74BE11CCB9312009DDBF1 /* QuotedTests.swift in Sources */,
 				508CA0FE2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift in Sources */,
 				F5C19F512283C0C100920B06 /* ResourceHelper.swift in Sources */,
+				508CA1062772039E0084C8E8 /* CSVDelimiterTests.swift in Sources */,
 				508975E21DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */,
 				5015AD8B274BA20A0050F975 /* ParserTests.swift in Sources */,
 				5FB74BE21CCB9312009DDBF1 /* TSVTests.swift in Sources */,
@@ -646,6 +653,7 @@
 				5FB74BE61CCB931F009DDBF1 /* QuotedTests.swift in Sources */,
 				508CA0FF2771F3260084C8E8 /* CSV+DelimiterGuessingTests.swift in Sources */,
 				F5C19F522283C0C300920B06 /* ResourceHelper.swift in Sources */,
+				508CA1072772039E0084C8E8 /* CSVDelimiterTests.swift in Sources */,
 				508975E31DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */,
 				5015AD8C274BA20A0050F975 /* ParserTests.swift in Sources */,
 				5FB74BE71CCB931F009DDBF1 /* TSVTests.swift in Sources */,

--- a/SwiftCSV/CSV+DelimiterGuessing.swift
+++ b/SwiftCSV/CSV+DelimiterGuessing.swift
@@ -1,0 +1,49 @@
+//
+//  CSV+DelimiterGuessing.swift
+//  SwiftCSV
+//
+//  Created by Christian Tietze on 21.12.21.
+//  Copyright © 2021 SwiftCSV. All rights reserved.
+//
+
+import Foundation
+
+extension CSV {
+    public static let recognizedDelimiters = [CSV.comma, CSV.tab, CSV.semicolon]
+
+    /// - Returns: Delimiter between cells based on the first line in the CSV. Falls back to comma.
+    public static func guessedDelimiter(string: String) -> Character {
+        // Trim newline and spaces, but keep tabs (as delimiters)
+        var trimmedCharacters = CharacterSet.whitespacesAndNewlines
+        trimmedCharacters.remove("\t")
+        let line = string.trimmingCharacters(in: trimmedCharacters).firstLine
+
+        var index = line.startIndex
+        while index < line.endIndex {
+            let character = line[index]
+            switch character {
+            case "\"":
+                // When encountering an open quote, skip to the closing counterpart.
+                // If none is found, skip to end of line.
+
+                // 1) Advance one character to skip the quote
+                index = line.index(after: index)
+
+                // 2) Look for the closing quote and move current position after it
+                if index < line.endIndex,
+                   let closingQuoteInddex = line[index...].firstIndex(of: character) {
+                    index = line.index(after: closingQuoteInddex)
+                } else {
+                    index = line.endIndex
+                }
+            case _ where recognizedDelimiters.contains(character):
+                return character
+            default:
+                index = line.index(after: index)
+            }
+        }
+
+        // Fallback value
+        return comma
+    }
+}

--- a/SwiftCSV/CSV+DelimiterGuessing.swift
+++ b/SwiftCSV/CSV+DelimiterGuessing.swift
@@ -9,10 +9,12 @@
 import Foundation
 
 extension CSV {
-    public static let recognizedDelimiters = [CSV.comma, CSV.tab, CSV.semicolon]
+    public static let recognizedDelimiters: [Delimiter] = [.comma, .tab, .semicolon]
 
-    /// - Returns: Delimiter between cells based on the first line in the CSV. Falls back to comma.
-    public static func guessedDelimiter(string: String) -> Character {
+    /// - Returns: Delimiter between cells based on the first line in the CSV. Falls back to `.comma`.
+    public static func guessedDelimiter(string: String) -> Delimiter {
+        let recognizedDelimiterCharacters = recognizedDelimiters.map(\.rawValue)
+
         // Trim newline and spaces, but keep tabs (as delimiters)
         var trimmedCharacters = CharacterSet.whitespacesAndNewlines
         trimmedCharacters.remove("\t")
@@ -36,14 +38,14 @@ extension CSV {
                 } else {
                     index = line.endIndex
                 }
-            case _ where recognizedDelimiters.contains(character):
-                return character
+            case _ where recognizedDelimiterCharacters.contains(character):
+                return Delimiter(rawValue: character)
             default:
                 index = line.index(after: index)
             }
         }
 
         // Fallback value
-        return comma
+        return .comma
     }
 }

--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -26,6 +26,35 @@ open class CSV {
 
     /// Used by exporters producing TSV, or tab-separated values.
     static public let tab: Character = "\t"
+
+    public enum Delimiter: Equatable, ExpressibleByUnicodeScalarLiteral {
+        public typealias UnicodeScalarLiteralType = Character
+
+        case comma, semicolon, tab
+        case character(Character)
+
+        public init(unicodeScalarLiteral: Character) {
+            self.init(rawValue: unicodeScalarLiteral)
+        }
+
+        init(rawValue: Character) {
+            switch rawValue {
+            case ",":  self = .comma
+            case ";":  self = .semicolon
+            case "\t": self = .tab
+            default:   self = .character(rawValue)
+            }
+        }
+
+        public var rawValue: Character {
+            switch self {
+            case .comma: return ","
+            case .semicolon: return ";"
+            case .tab: return "\t"
+            case .character(let character): return character
+            }
+        }
+    }
     
     public let header: [String]
 

--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -20,6 +20,12 @@ public protocol CSVView {
 
 open class CSV {
     static public let comma: Character = ","
+
+    /// Used by exporters such as DEVONthink, Excel.
+    static public let semicolon: Character = ";"
+
+    /// Used by exporters producing TSV, or tab-separated values.
+    static public let tab: Character = "\t"
     
     public let header: [String]
 

--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -83,16 +83,28 @@ open class CSV {
         return namedColumns
     }
 
-    
+
     /// Load CSV data from a string.
     ///
     /// - parameter string: CSV contents to parse.
-    /// - parameter delimiter: Character used to separate  row and header fields (default is ',')
+    /// - parameter delimiter: Character used to separate  row and header fields (default is '","')
     /// - parameter loadColumns: Whether to populate the `columns` dictionary (default is `true`)
     /// - throws: `CSVParseError` when parsing `string` fails.
     public init(string: String, delimiter: Character = comma, loadColumns: Bool = true) throws {
         self.text = string
         self.delimiter = delimiter
+        self.loadColumns = loadColumns
+        self.header = try Parser.array(text: string, delimiter: delimiter, rowLimit: 1).first ?? []
+    }
+
+    /// Load CSV data from a string and guess its delimiter from `CSV.recognizedDelimiters`, falling back to comma (`","`).
+    ///
+    /// - parameter string: CSV contents to parse.
+    /// - parameter loadColumns: Whether to populate the `columns` dictionary (default is `true`)
+    /// - throws: `CSVParseError` when parsing `string` fails.
+    public init(string: String, loadColumns: Bool = true) throws {
+        self.text = string
+        self.delimiter = CSV.guessedDelimiter(string: string)
         self.loadColumns = loadColumns
         self.header = try Parser.array(text: string, delimiter: delimiter, rowLimit: 1).first ?? []
     }

--- a/SwiftCSV/EnumeratedView.swift
+++ b/SwiftCSV/EnumeratedView.swift
@@ -18,7 +18,7 @@ public struct EnumeratedView: CSVView {
     public private(set) var rows: [[String]]
     public private(set) var columns: [Column]
 
-    public init(header: [String], text: String, delimiter: Character, limitTo: Int? = nil, loadColumns: Bool = false) throws {
+    public init(header: [String], text: String, delimiter: CSV.Delimiter, limitTo: Int? = nil, loadColumns: Bool = false) throws {
 
         var rows = [[String]]()
         var columns: [EnumeratedView.Column] = []

--- a/SwiftCSV/NamedView.swift
+++ b/SwiftCSV/NamedView.swift
@@ -11,7 +11,7 @@ public struct NamedView: CSVView {
     public var rows: [[String : String]]
     public var columns: [String : [String]]
 
-    public init(header: [String], text: String, delimiter: Character, limitTo: Int? = nil, loadColumns: Bool = false) throws {
+    public init(header: [String], text: String, delimiter: CSV.Delimiter, limitTo: Int? = nil, loadColumns: Bool = false) throws {
 
         var rows = [[String: String]]()
         var columns = [String: [String]]()

--- a/SwiftCSV/Parser.swift
+++ b/SwiftCSV/Parser.swift
@@ -34,7 +34,7 @@ extension CSV {
 
 enum Parser {
 
-    static func array(text: String, delimiter: Character, startAt offset: Int = 0, rowLimit: Int? = nil) throws -> [[String]] {
+    static func array(text: String, delimiter: CSV.Delimiter, startAt offset: Int = 0, rowLimit: Int? = nil) throws -> [[String]] {
 
         var rows = [[String]]()
 
@@ -57,17 +57,17 @@ enum Parser {
     ///   - rowCallback: Callback invoked for every parsed row between `startAt` and `limitTo` in `text`.
     /// - Throws: `CSVParseError`
     static func enumerateAsArray(text: String,
-                                 delimiter: Character,
+                                 delimiter: CSV.Delimiter,
                                  startAt offset: Int = 0,
                                  rowLimit: Int? = nil,
                                  rowCallback: @escaping ([String]) -> ()) throws {
-
         let maxRowIndex = rowLimit.flatMap { $0 < 0 ? nil : offset + $0 }
 
         var currentIndex = text.startIndex
         let endIndex = text.endIndex
 
         var fields = [String]()
+        let delimiter = delimiter.rawValue
         var field = ""
 
         var rowIndex = 0
@@ -123,7 +123,7 @@ enum Parser {
         }
     }
 
-    static func enumerateAsDict(header: [String], content: String, delimiter: Character, rowLimit: Int? = nil, block: @escaping ([String : String]) -> ()) throws {
+    static func enumerateAsDict(header: [String], content: String, delimiter: CSV.Delimiter, rowLimit: Int? = nil, block: @escaping ([String : String]) -> ()) throws {
 
         let enumeratedHeader = header.enumerated()
 

--- a/SwiftCSVTests/CSV+DelimiterGuessingTests.swift
+++ b/SwiftCSVTests/CSV+DelimiterGuessingTests.swift
@@ -55,4 +55,27 @@ class CSV_DelimiterGuessingTests: XCTestCase {
         XCTAssertEqual(CSV.guessedDelimiter(string: "\na\tb\tc"), CSV.tab)
         XCTAssertEqual(CSV.guessedDelimiter(string: "\n  \n \na\tb\tc"), CSV.tab)
     }
+
+    
+    func testInitWithGuessedDelimiter() {
+        let semicolonCSV = try! CSV(string: "id;name;age\n1;Alice;18\n2;Bob;19\n3;Charlie")
+        let expectedSemicolonCSV = [
+            ["id": "1", "name": "Alice", "age": "18"],
+            ["id": "2", "name": "Bob", "age": "19"],
+            ["id": "3", "name": "Charlie", "age": ""]
+        ]
+        for (index, row) in semicolonCSV.namedRows.enumerated() {
+            XCTAssertEqual(expectedSemicolonCSV[index], row)
+        }
+
+        let tabCSV = try! CSV(string: "id\tname\tage\n1\tAlice\t18\n2\tBob\t19\n3\tCharlie")
+        let expectedTabCSV = [
+            ["id": "1", "name": "Alice", "age": "18"],
+            ["id": "2", "name": "Bob", "age": "19"],
+            ["id": "3", "name": "Charlie", "age": ""]
+        ]
+        for (index, row) in tabCSV.namedRows.enumerated() {
+            XCTAssertEqual(expectedTabCSV[index], row)
+        }
+    }
 }

--- a/SwiftCSVTests/CSV+DelimiterGuessingTests.swift
+++ b/SwiftCSVTests/CSV+DelimiterGuessingTests.swift
@@ -11,49 +11,49 @@ import XCTest
 
 class CSV_DelimiterGuessingTests: XCTestCase {
     func testGuessDelimiter_InvalidInput_FallbackToComma() throws {
-        XCTAssertEqual(CSV.guessedDelimiter(string: ""), CSV.comma)
-        XCTAssertEqual(CSV.guessedDelimiter(string: "    "), CSV.comma)
-        XCTAssertEqual(CSV.guessedDelimiter(string: "fallback"), CSV.comma)
-        XCTAssertEqual(CSV.guessedDelimiter(string: #""opened;quote;never;closed"#), CSV.comma)
-        XCTAssertEqual(CSV.guessedDelimiter(string: "just a single line of text"), CSV.comma)
-        XCTAssertEqual(CSV.guessedDelimiter(string: "\n"), CSV.comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: ""), .comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "    "), .comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "fallback"), .comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: #""opened;quote;never;closed"#), .comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "just a single line of text"), .comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\n"), .comma)
     }
 
     func testGuessDelimiter_Comma() throws {
-        XCTAssertEqual(CSV.guessedDelimiter(string: "header,"), CSV.comma)
-        XCTAssertEqual(CSV.guessedDelimiter(string: "id,name,age"), CSV.comma)
-        XCTAssertEqual(CSV.guessedDelimiter(string: #""a","b","c""#), CSV.comma)
-        XCTAssertEqual(CSV.guessedDelimiter(string: #""a;","b\t","c""#), CSV.comma,
+        XCTAssertEqual(CSV.guessedDelimiter(string: "header,"), .comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "id,name,age"), .comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: #""a","b","c""#), .comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: #""a;","b\t","c""#), .comma,
                        "Prioritizes separator between quotations over first occurrence")
     }
 
     func testGuessDelimiter_Semicolon() throws {
-        XCTAssertEqual(CSV.guessedDelimiter(string: "header;"), CSV.semicolon)
-        XCTAssertEqual(CSV.guessedDelimiter(string: "id;name;age"), CSV.semicolon)
-        XCTAssertEqual(CSV.guessedDelimiter(string: #""a";"b";"c""#), CSV.semicolon)
-        XCTAssertEqual(CSV.guessedDelimiter(string: #""a,";"b\t";"c""#), CSV.semicolon,
+        XCTAssertEqual(CSV.guessedDelimiter(string: "header;"), .semicolon)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "id;name;age"), .semicolon)
+        XCTAssertEqual(CSV.guessedDelimiter(string: #""a";"b";"c""#), .semicolon)
+        XCTAssertEqual(CSV.guessedDelimiter(string: #""a,";"b\t";"c""#), .semicolon,
                        "Prioritizes separator between quotations over first occurrence")
     }
 
     func testGuessDelimiter_Tab() throws {
-        XCTAssertEqual(CSV.guessedDelimiter(string: "header\t"), CSV.tab)
-        XCTAssertEqual(CSV.guessedDelimiter(string: "id\tname\tage"), CSV.tab)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "header\t"), .tab)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "id\tname\tage"), .tab)
         // We cannot use #"..."# string delimiters here because \t doesn't work inside these.
-        XCTAssertEqual(CSV.guessedDelimiter(string: "\"a\"\t\"b\"\t\"c\""), CSV.tab)
-        XCTAssertEqual(CSV.guessedDelimiter(string: "\"a,\"\t\"b;\"\t\"c\""), CSV.tab,
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\"a\"\t\"b\"\t\"c\""), .tab)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\"a,\"\t\"b;\"\t\"c\""), .tab,
                        "Prioritizes separator between quotations over first occurrence")
     }
 
     func testGuessDelimiter_IgnoresEmptyLeadingLines() throws {
-        XCTAssertEqual(CSV.guessedDelimiter(string: "\na,b,c"), CSV.comma)
-        XCTAssertEqual(CSV.guessedDelimiter(string: "\n\n\na,b,c"), CSV.comma)
-        XCTAssertEqual(CSV.guessedDelimiter(string: "\n  \n \na,b,c"), CSV.comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\na,b,c"), .comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\n\n\na,b,c"), .comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\n  \n \na,b,c"), .comma)
 
-        XCTAssertEqual(CSV.guessedDelimiter(string: "\na;b;c"), CSV.semicolon)
-        XCTAssertEqual(CSV.guessedDelimiter(string: "\n  \n \na;b;c"), CSV.semicolon)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\na;b;c"), .semicolon)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\n  \n \na;b;c"), .semicolon)
 
-        XCTAssertEqual(CSV.guessedDelimiter(string: "\na\tb\tc"), CSV.tab)
-        XCTAssertEqual(CSV.guessedDelimiter(string: "\n  \n \na\tb\tc"), CSV.tab)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\na\tb\tc"), .tab)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\n  \n \na\tb\tc"), .tab)
     }
 
     

--- a/SwiftCSVTests/CSV+DelimiterGuessingTests.swift
+++ b/SwiftCSVTests/CSV+DelimiterGuessingTests.swift
@@ -1,0 +1,58 @@
+//
+//  CSV+DelimiterGuessingTests.swift
+//  SwiftCSV
+//
+//  Created by Christian Tietze on 21.12.21.
+//  Copyright © 2021 Naoto Kaneko. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftCSV
+
+class CSV_DelimiterGuessingTests: XCTestCase {
+    func testGuessDelimiter_InvalidInput_FallbackToComma() throws {
+        XCTAssertEqual(CSV.guessedDelimiter(string: ""), CSV.comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "    "), CSV.comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "fallback"), CSV.comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: #""opened;quote;never;closed"#), CSV.comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "just a single line of text"), CSV.comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\n"), CSV.comma)
+    }
+
+    func testGuessDelimiter_Comma() throws {
+        XCTAssertEqual(CSV.guessedDelimiter(string: "header,"), CSV.comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "id,name,age"), CSV.comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: #""a","b","c""#), CSV.comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: #""a;","b\t","c""#), CSV.comma,
+                       "Prioritizes separator between quotations over first occurrence")
+    }
+
+    func testGuessDelimiter_Semicolon() throws {
+        XCTAssertEqual(CSV.guessedDelimiter(string: "header;"), CSV.semicolon)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "id;name;age"), CSV.semicolon)
+        XCTAssertEqual(CSV.guessedDelimiter(string: #""a";"b";"c""#), CSV.semicolon)
+        XCTAssertEqual(CSV.guessedDelimiter(string: #""a,";"b\t";"c""#), CSV.semicolon,
+                       "Prioritizes separator between quotations over first occurrence")
+    }
+
+    func testGuessDelimiter_Tab() throws {
+        XCTAssertEqual(CSV.guessedDelimiter(string: "header\t"), CSV.tab)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "id\tname\tage"), CSV.tab)
+        // We cannot use #"..."# string delimiters here because \t doesn't work inside these.
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\"a\"\t\"b\"\t\"c\""), CSV.tab)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\"a,\"\t\"b;\"\t\"c\""), CSV.tab,
+                       "Prioritizes separator between quotations over first occurrence")
+    }
+
+    func testGuessDelimiter_IgnoresEmptyLeadingLines() throws {
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\na,b,c"), CSV.comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\n\n\na,b,c"), CSV.comma)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\n  \n \na,b,c"), CSV.comma)
+
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\na;b;c"), CSV.semicolon)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\n  \n \na;b;c"), CSV.semicolon)
+
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\na\tb\tc"), CSV.tab)
+        XCTAssertEqual(CSV.guessedDelimiter(string: "\n  \n \na\tb\tc"), CSV.tab)
+    }
+}

--- a/SwiftCSVTests/CSVDelimiterTests.swift
+++ b/SwiftCSVTests/CSVDelimiterTests.swift
@@ -1,0 +1,26 @@
+//
+//  CSVDelimiterTests.swift
+//  SwiftCSV
+//
+//  Created by Christian Tietze on 21.12.21.
+//  Copyright © 2021 SwiftCSV. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftCSV
+
+class CSVDelimiterTests: XCTestCase {
+    func testRawValue() {
+        XCTAssertEqual(CSV.Delimiter.comma.rawValue, ",")
+        XCTAssertEqual(CSV.Delimiter.semicolon.rawValue, ";")
+        XCTAssertEqual(CSV.Delimiter.tab.rawValue, "\t")
+        XCTAssertEqual(CSV.Delimiter.character("x").rawValue, "x")
+    }
+
+    func testLiteralInitializer() {
+        XCTAssertEqual(CSV.Delimiter.comma, ",")
+        XCTAssertEqual(CSV.Delimiter.semicolon, ";")
+        XCTAssertEqual(CSV.Delimiter.tab, "\t")
+        XCTAssertEqual(CSV.Delimiter.character("x"), "x")
+    }
+}

--- a/SwiftCSVTests/CSVTests.swift
+++ b/SwiftCSVTests/CSVTests.swift
@@ -13,7 +13,7 @@ class CSVTests: XCTestCase {
     var csv: CSV!
     
     override func setUp() {
-        csv = try! CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie,20", delimiter: CSV.comma)
+        csv = try! CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie,20", delimiter: .comma)
     }
     
     func testInit_makesHeader() {
@@ -32,7 +32,7 @@ class CSVTests: XCTestCase {
     }
     
     func testInit_whenThereAreIncompleteRows_makesRows() {
-        csv = try! CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie", delimiter: CSV.comma)
+        csv = try! CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie", delimiter: .comma)
         let expected = [
             ["id": "1", "name": "Alice", "age": "18"],
             ["id": "2", "name": "Bob", "age": "19"],
@@ -56,7 +56,7 @@ class CSVTests: XCTestCase {
     }
     
     func testInit_whenThereAreCRLFs_makesRows() {
-        csv = try! CSV(string: "id,name,age\r\n1,Alice,18\r\n2,Bob,19\r\n3,Charlie,20\r\n", delimiter: CSV.comma)
+        csv = try! CSV(string: "id,name,age\r\n1,Alice,18\r\n2,Bob,19\r\n3,Charlie,20\r\n", delimiter: .comma)
         let expected = [
             ["id": "1", "name": "Alice", "age": "18"],
             ["id": "2", "name": "Bob", "age": "19"],
@@ -84,7 +84,7 @@ class CSVTests: XCTestCase {
     }
   
     func testDescriptionWithDoubleQuotes() {
-        csv = try! CSV(string: "id,name,age\n1,\"Alice, In, Wonderland\",18\n2,Bob,19\n3,Charlie,20", delimiter: CSV.comma)
+        csv = try! CSV(string: "id,name,age\n1,\"Alice, In, Wonderland\",18\n2,Bob,19\n3,Charlie,20", delimiter: .comma)
         XCTAssertEqual(csv.description, "id,name,age\n1,\"Alice, In, Wonderland\",18\n2,Bob,19\n3,Charlie,20")
     }
   
@@ -102,7 +102,7 @@ class CSVTests: XCTestCase {
     }
 
     func testIgnoreColumns() {
-        csv = try! CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie,20", delimiter: CSV.comma, loadColumns: false)
+        csv = try! CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie,20", delimiter: .comma, loadColumns: false)
         XCTAssertEqual(csv.namedColumns.isEmpty, true)
         let expected = [
             ["id": "1", "name": "Alice", "age": "18"],
@@ -123,7 +123,7 @@ class CSVTests: XCTestCase {
         "a" \(tab)  ,  \(paragraphSeparator)  "b"
         "A" \(ideographicSpace)  ,  \(tab)   "B"
         """
-        let csv = try! CSV(string: failingCsv, delimiter: CSV.comma)
+        let csv = try! CSV(string: failingCsv, delimiter: .comma)
         
         XCTAssertEqual(csv.namedRows, [["b": "B", "a": "A"]])
     }

--- a/SwiftCSVTests/CSVTests.swift
+++ b/SwiftCSVTests/CSVTests.swift
@@ -13,7 +13,7 @@ class CSVTests: XCTestCase {
     var csv: CSV!
     
     override func setUp() {
-        csv = try! CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie,20")
+        csv = try! CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie,20", delimiter: CSV.comma)
     }
     
     func testInit_makesHeader() {
@@ -32,7 +32,7 @@ class CSVTests: XCTestCase {
     }
     
     func testInit_whenThereAreIncompleteRows_makesRows() {
-        csv = try! CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie")
+        csv = try! CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie", delimiter: CSV.comma)
         let expected = [
             ["id": "1", "name": "Alice", "age": "18"],
             ["id": "2", "name": "Bob", "age": "19"],
@@ -56,7 +56,7 @@ class CSVTests: XCTestCase {
     }
     
     func testInit_whenThereAreCRLFs_makesRows() {
-        csv = try! CSV(string: "id,name,age\r\n1,Alice,18\r\n2,Bob,19\r\n3,Charlie,20\r\n")
+        csv = try! CSV(string: "id,name,age\r\n1,Alice,18\r\n2,Bob,19\r\n3,Charlie,20\r\n", delimiter: CSV.comma)
         let expected = [
             ["id": "1", "name": "Alice", "age": "18"],
             ["id": "2", "name": "Bob", "age": "19"],
@@ -84,7 +84,7 @@ class CSVTests: XCTestCase {
     }
   
     func testDescriptionWithDoubleQuotes() {
-        csv = try! CSV(string: "id,name,age\n1,\"Alice, In, Wonderland\",18\n2,Bob,19\n3,Charlie,20")
+        csv = try! CSV(string: "id,name,age\n1,\"Alice, In, Wonderland\",18\n2,Bob,19\n3,Charlie,20", delimiter: CSV.comma)
         XCTAssertEqual(csv.description, "id,name,age\n1,\"Alice, In, Wonderland\",18\n2,Bob,19\n3,Charlie,20")
     }
   
@@ -102,7 +102,7 @@ class CSVTests: XCTestCase {
     }
 
     func testIgnoreColumns() {
-        csv = try! CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie,20", delimiter: ",", loadColumns: false)
+        csv = try! CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie,20", delimiter: CSV.comma, loadColumns: false)
         XCTAssertEqual(csv.namedColumns.isEmpty, true)
         let expected = [
             ["id": "1", "name": "Alice", "age": "18"],
@@ -123,7 +123,7 @@ class CSVTests: XCTestCase {
         "a" \(tab)  ,  \(paragraphSeparator)  "b"
         "A" \(ideographicSpace)  ,  \(tab)   "B"
         """
-        let csv = try! CSV(string: failingCsv)
+        let csv = try! CSV(string: failingCsv, delimiter: CSV.comma)
         
         XCTAssertEqual(csv.namedRows, [["b": "B", "a": "A"]])
     }


### PR DESCRIPTION
In the app where I use SwiftCSV, users often try to import CSV with either tabs or semicolons as delimiters. 

I figured delimiter guessing is useful for everyone, not just users of my app, so here's an attempt to add that functionality.

What do you think about these changes? 

If we merge this, I'd bump the version to v0.7.0 because this is breaking backwards compatibility.