### PR TITLE
Add the 0.7.1 version info to the changelog on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ API Changes:
     - CSV.namedRows/CSV.namedColumns and CSV.enumeratedRows/CSV.enumeratedColumns are removed.
     - NamedCSV/EnumeratedCSV type aliases are introduced to simplify access.
 
+
+## 0.7.1
+
+Bugfixes:
+
+- Backport of fix from 0.8.1 to 0.7.x: Strip byte order mark from Strings when importing so they don't become part of imported content's cells. 
+  See #97 for discussion. (#104) -- @lardieri
+
+
 ## 0.7.0
 
 API Changes:


### PR DESCRIPTION
Important: Please do not squash or rebase!

I've set this up as a merge commit, specifically so it accomplishes two desirable goals:

- Add the 0.7.1 version info to the changelog on `master`.
- Additionally, close out the `v0.7` branch by joining it back into `master`, so we don't carry around an appendix branch forever.

If you want to see what this looks like, you should clone my fork and use a graphical visualizer ("subway map") to look at the branch structure.

Please let me know if you have any questions.